### PR TITLE
[Feature] 규칙 도메인 설계 및 구현

### DIFF
--- a/src/main/java/skhu/hanziboong/global/BaseEntity.java
+++ b/src/main/java/skhu/hanziboong/global/BaseEntity.java
@@ -1,0 +1,23 @@
+package skhu.hanziboong.global;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/skhu/hanziboong/house/domain/House.java
+++ b/src/main/java/skhu/hanziboong/house/domain/House.java
@@ -1,0 +1,31 @@
+package skhu.hanziboong.house.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import skhu.hanziboong.global.BaseEntity;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class House extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private HouseType houseType;
+
+    public House(HouseType houseType) {
+        this.houseType = houseType;
+    }
+}

--- a/src/main/java/skhu/hanziboong/house/domain/HouseType.java
+++ b/src/main/java/skhu/hanziboong/house/domain/HouseType.java
@@ -1,0 +1,5 @@
+package skhu.hanziboong.house.domain;
+
+public enum HouseType {
+    MONTHLY_RENT, DORMITORY, SHARE_HOUSE
+}

--- a/src/main/java/skhu/hanziboong/member/domain/Member.java
+++ b/src/main/java/skhu/hanziboong/member/domain/Member.java
@@ -1,0 +1,41 @@
+package skhu.hanziboong.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import skhu.hanziboong.global.BaseEntity;
+import skhu.hanziboong.house.domain.House;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @JoinColumn(nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private House house;
+
+    public Member(String username, String nickname, House house) {
+        this.username = username;
+        this.nickname = nickname;
+        this.house = house;
+    }
+}

--- a/src/main/java/skhu/hanziboong/rule/controller/RuleController.java
+++ b/src/main/java/skhu/hanziboong/rule/controller/RuleController.java
@@ -1,0 +1,57 @@
+package skhu.hanziboong.rule.controller;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import skhu.hanziboong.rule.dto.request.RuleRequest;
+import skhu.hanziboong.rule.dto.response.RuleCreateResponse;
+import skhu.hanziboong.rule.dto.response.RuleResponse;
+import skhu.hanziboong.rule.service.RuleService;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/rules")
+public class RuleController {
+
+    private final RuleService ruleService;
+
+    @PostMapping
+    public ResponseEntity<Void> createRule(
+            @RequestBody RuleRequest request
+    ) {
+        RuleCreateResponse response = ruleService.createRule(request);
+
+        return ResponseEntity.created(URI.create("/api/rules/" + response.id())).build();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<RuleResponse> findRule(@PathVariable Long id) {
+        return ResponseEntity.ok(ruleService.findRuleById(id));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> updateRule(
+            @PathVariable Long id,
+            @RequestBody RuleRequest request
+    ) {
+        ruleService.updateRuleById(id, request);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteRule(@PathVariable Long id) {
+        ruleService.deleteRuleById(id);
+
+        return ResponseEntity.noContent()
+                .build();
+    }
+}

--- a/src/main/java/skhu/hanziboong/rule/domain/Rule.java
+++ b/src/main/java/skhu/hanziboong/rule/domain/Rule.java
@@ -1,0 +1,75 @@
+package skhu.hanziboong.rule.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import skhu.hanziboong.global.BaseEntity;
+import skhu.hanziboong.house.domain.House;
+import skhu.hanziboong.member.domain.Member;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Rule extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String description;
+
+    @JoinColumn(nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member author;
+
+    @JoinColumn(nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private House house;
+
+    public Rule(String title, String description, Member author) {
+        this(title, description, author, author.getHouse());
+    }
+
+    private Rule(String title, String description, Member author, House house) {
+        validateNotBlank(title);
+        this.title = title;
+        this.description = description;
+        this.author = author;
+        this.house = house;
+    }
+
+    private void validateNotBlank(String title) {
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("규칙 제목, 규칙 설명은 비어있을 수 없습니다.");
+        }
+    }
+
+    public void update(String title, String description) {
+        validateNotBlank(title);
+        this.title = title;
+        this.description = description;
+    }
+
+    public Long getAuthorId() {
+        return author.getId();
+    }
+
+    public String getAuthorNickname() {
+        return author.getNickname();
+    }
+
+    public Long getHouseId() {
+        return house.getId();
+    }
+}

--- a/src/main/java/skhu/hanziboong/rule/dto/request/RuleRequest.java
+++ b/src/main/java/skhu/hanziboong/rule/dto/request/RuleRequest.java
@@ -1,0 +1,18 @@
+package skhu.hanziboong.rule.dto.request;
+
+import skhu.hanziboong.house.domain.House;
+import skhu.hanziboong.house.domain.HouseType;
+import skhu.hanziboong.member.domain.Member;
+import skhu.hanziboong.rule.domain.Rule;
+
+public record RuleRequest(
+        String title,
+        String description
+) {
+    public Rule toRule() {
+        // TODO: house와 member는 임시 객체이므로 기능 구현 후 대체해야 함.
+        House house = new House(HouseType.MONTHLY_RENT);
+        Member member = new Member("username", "nickname", house);
+        return new Rule(title, description, member);
+    }
+}

--- a/src/main/java/skhu/hanziboong/rule/dto/response/RuleCreateResponse.java
+++ b/src/main/java/skhu/hanziboong/rule/dto/response/RuleCreateResponse.java
@@ -1,0 +1,11 @@
+package skhu.hanziboong.rule.dto.response;
+
+import skhu.hanziboong.rule.domain.Rule;
+
+public record RuleCreateResponse(
+        Long id
+) {
+    public static RuleCreateResponse from(Rule rule) {
+        return new RuleCreateResponse(rule.getId());
+    }
+}

--- a/src/main/java/skhu/hanziboong/rule/dto/response/RuleResponse.java
+++ b/src/main/java/skhu/hanziboong/rule/dto/response/RuleResponse.java
@@ -1,0 +1,25 @@
+package skhu.hanziboong.rule.dto.response;
+
+import lombok.Builder;
+import skhu.hanziboong.rule.domain.Rule;
+
+@Builder
+public record RuleResponse(
+        Long id,
+        String title,
+        String description,
+        Long authorId,
+        String authorNickname,
+        Long houseId
+) {
+    public static RuleResponse from(Rule rule) {
+        return RuleResponse.builder()
+                .id(rule.getId())
+                .title(rule.getTitle())
+                .description(rule.getDescription())
+                .authorId(rule.getAuthorId())
+                .authorNickname(rule.getAuthorNickname())
+                .houseId(rule.getHouseId())
+                .build();
+    }
+}

--- a/src/main/java/skhu/hanziboong/rule/repository/RuleRepository.java
+++ b/src/main/java/skhu/hanziboong/rule/repository/RuleRepository.java
@@ -1,0 +1,9 @@
+package skhu.hanziboong.rule.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import skhu.hanziboong.rule.domain.Rule;
+
+@Repository
+public interface RuleRepository extends JpaRepository<Rule, Long> {
+}

--- a/src/main/java/skhu/hanziboong/rule/service/RuleService.java
+++ b/src/main/java/skhu/hanziboong/rule/service/RuleService.java
@@ -1,0 +1,45 @@
+package skhu.hanziboong.rule.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import skhu.hanziboong.rule.domain.Rule;
+import skhu.hanziboong.rule.dto.request.RuleRequest;
+import skhu.hanziboong.rule.dto.response.RuleCreateResponse;
+import skhu.hanziboong.rule.dto.response.RuleResponse;
+import skhu.hanziboong.rule.repository.RuleRepository;
+
+@RequiredArgsConstructor
+@Service
+public class RuleService {
+
+    private final RuleRepository ruleRepository;
+
+    @Transactional
+    public RuleCreateResponse createRule(RuleRequest request) {
+        Rule rule = ruleRepository.save(request.toRule());
+
+        return RuleCreateResponse.from(rule);
+    }
+
+    @Transactional(readOnly = true)
+    public RuleResponse findRuleById(Long id) {
+        Rule rule = ruleRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 규칙입니다."));
+
+        return RuleResponse.from(rule);
+    }
+
+    @Transactional
+    public void updateRuleById(Long id, RuleRequest request) {
+        Rule rule = ruleRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 규칙입니다."));
+
+        rule.update(request.title(), request.description());
+    }
+
+    @Transactional
+    public void deleteRuleById(Long id) {
+        ruleRepository.deleteById(id);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=hanziboong-backend

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
       enabled: true
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:touroot
+    url: jdbc:h2:mem:hanziboong
     username: sa
   jpa:
     show-sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+# local profile
+spring:
+  h2:
+    console:
+      enabled: true
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:touroot
+    username: sa
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create


### PR DESCRIPTION
## 작업 내용

- 작성한 ERD를 기반으로 Rule 도메인과 Member, House 도메인을 구현했습니다.
- Rule 도메인을 영속화하기 위한 Repository 계층을 추가했습니다.
- Rule 도메인의 비즈니스 로직을 구현하기 위한 Service 계층을 추가했습니다.
- Rule 도메인의 CRUD API를 구현하기 위한 Controller 계층을 추가했습니다.
- Controller 계층에서 활용하기 위해 Record 기반 요청, 응답 DTO를 구현했습니다.

## 참고 사항

1. 아직 단위 테스트는 작성하지 않았습니다. 정기 회의 후 작성 예정입니다.'
2. Swagger와 같은 Rest Docs 관련 회의가 필요합니다.
3. Member와 House는 Rule과 일정 도메인 모두 활용하므로 임시로 작성했습니다. 관련 회의가 필요합니다.
