### PR TITLE
[Feature] 집, 사용자 도메인 설계 및 구현과 API 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,46 +1,52 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.4'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.4'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'skhu'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 bootJar {
-	enabled = true
-	archiveFileName = 'app.jar'
-	mainClass = 'skhu.hanziboong.HanziboongBackendApplication'
+    enabled = true
+    archiveFileName = 'app.jar'
+    mainClass = 'skhu.hanziboong.HanziboongBackendApplication'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+    compileOnly 'org.projectlombok:lombok'
+
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    annotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/skhu/hanziboong/global/exception/ErrorCode.java
+++ b/src/main/java/skhu/hanziboong/global/exception/ErrorCode.java
@@ -11,12 +11,12 @@ public enum ErrorCode {
 
     // 400 Bad Request
     VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    PASSWORD_MISMATCH_EXCEPTION(HttpStatus.BAD_REQUEST,"존재하지 않는 비밀번호 or 비밀번호가 잘못되었습니다"),
+    PASSWORD_MISMATCH_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 비밀번호 or 비밀번호가 잘못되었습니다"),
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "필수적인 요청 값이 입력되지 않았습니다."),
     VALIDATION_REQUEST_HEADER_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 헤더값이 입력되지 않았습니다."),
     VALIDATION_REQUEST_PARAMETER_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 파라미터값이 입력되지 않았습니다."),
     REQUEST_METHOD_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 메소드가 잘못됐습니다."),
-    VALIDATION_REQUEST_FAIL_USERINFO_EXCEPTION(HttpStatus.BAD_REQUEST,"사용자 정보를 받아오는데 실패했습니다."),
+    VALIDATION_REQUEST_FAIL_USERINFO_EXCEPTION(HttpStatus.BAD_REQUEST, "사용자 정보를 받아오는데 실패했습니다."),
     VALIDATION_JSON_SYNTAX_FAIL(HttpStatus.BAD_REQUEST, "JSON 파싱 오류 발생"),
     INVALID_ROLE_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "올바르지 않은 권한 요청입니다."),
     INVALID_ID_EXCEPTION(HttpStatus.BAD_REQUEST, "사용자 ID가 유효하지 않습니다. "),
@@ -54,8 +54,7 @@ public enum ErrorCode {
 
     // 503 Service Unavailable
     FAILED_GET_TOKEN_EXCEPTION(HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS, "구글 엑세스 토큰을 가져오는데 실패했습니다."),
-    FAILED_UPLOAD_IMAGE_FILE_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "이미지를 업로드하는데 실패했습니다. ")
-            ;
+    FAILED_UPLOAD_IMAGE_FILE_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "이미지를 업로드하는데 실패했습니다. ");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/skhu/hanziboong/global/exception/SuccessCode.java
+++ b/src/main/java/skhu/hanziboong/global/exception/SuccessCode.java
@@ -16,7 +16,6 @@ public enum SuccessCode {
     SMS_VERIFY_SUCCESS(HttpStatus.OK, "본인확인 인증에 성공했습니다");
 
     // 201 Created, Delete
-
     private final HttpStatus httpStatus;
     private final String message;
 

--- a/src/main/java/skhu/hanziboong/house/controller/HouseController.java
+++ b/src/main/java/skhu/hanziboong/house/controller/HouseController.java
@@ -1,0 +1,46 @@
+package skhu.hanziboong.house.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import skhu.hanziboong.global.exception.model.BadRequestException;
+import skhu.hanziboong.house.dto.request.HouseRequest;
+import skhu.hanziboong.house.dto.response.HouseCreateResponse;
+import skhu.hanziboong.house.service.HouseService;
+
+@Tag(name = "집")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/houses")
+public class HouseController {
+
+    private final HouseService houseService;
+
+    @Operation(summary = "집 생성")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "요청 Body에 올바르지 않은 값이 전달되었을 때",
+                    content = @Content(schema = @Schema(implementation = BadRequestException.class))
+            ),
+    })
+    @PostMapping
+    public ResponseEntity<HouseCreateResponse> createHouse(HouseRequest request) {
+        HouseCreateResponse response = houseService.createHouse(request);
+
+        return ResponseEntity.created(URI.create("/api/houses/" + response.id())).build();
+    }
+}

--- a/src/main/java/skhu/hanziboong/house/domain/House.java
+++ b/src/main/java/skhu/hanziboong/house/domain/House.java
@@ -1,24 +1,16 @@
 package skhu.hanziboong.house.domain;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import skhu.hanziboong.global.BaseEntity;
-import skhu.hanziboong.schedule.domain.Schedule;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/skhu/hanziboong/house/domain/HouseType.java
+++ b/src/main/java/skhu/hanziboong/house/domain/HouseType.java
@@ -1,5 +1,11 @@
 package skhu.hanziboong.house.domain;
 
 public enum HouseType {
-    MONTHLY_RENT, DORMITORY, SHARE_HOUSE
+    MONTHLY_RENT,
+    DORMITORY,
+    SHARE_HOUSE;
+
+    public static HouseType getType(String type) {
+        return HouseType.valueOf(type);
+    }
 }

--- a/src/main/java/skhu/hanziboong/house/dto/request/HouseRequest.java
+++ b/src/main/java/skhu/hanziboong/house/dto/request/HouseRequest.java
@@ -1,0 +1,13 @@
+package skhu.hanziboong.house.dto.request;
+
+import skhu.hanziboong.house.domain.House;
+import skhu.hanziboong.house.domain.HouseType;
+
+public record HouseRequest(
+        String type
+) {
+    public House toHouse() {
+        HouseType houseType = HouseType.getType(type);
+        return new House(houseType);
+    }
+}

--- a/src/main/java/skhu/hanziboong/house/dto/response/HouseCreateResponse.java
+++ b/src/main/java/skhu/hanziboong/house/dto/response/HouseCreateResponse.java
@@ -1,0 +1,11 @@
+package skhu.hanziboong.house.dto.response;
+
+import skhu.hanziboong.house.domain.House;
+
+public record HouseCreateResponse(
+        Long id
+) {
+    public static HouseCreateResponse from(House house) {
+        return new HouseCreateResponse(house.getId());
+    }
+}

--- a/src/main/java/skhu/hanziboong/house/service/HouseService.java
+++ b/src/main/java/skhu/hanziboong/house/service/HouseService.java
@@ -1,0 +1,23 @@
+package skhu.hanziboong.house.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import skhu.hanziboong.house.domain.House;
+import skhu.hanziboong.house.dto.request.HouseRequest;
+import skhu.hanziboong.house.dto.response.HouseCreateResponse;
+import skhu.hanziboong.house.repository.HouseRepository;
+
+@RequiredArgsConstructor
+@Service
+public class HouseService {
+
+    private final HouseRepository houseRepository;
+
+    @Transactional
+    public HouseCreateResponse createHouse(HouseRequest request) {
+        House house = houseRepository.save(request.toHouse());
+
+        return HouseCreateResponse.from(house);
+    }
+}

--- a/src/main/java/skhu/hanziboong/member/controller/MemberController.java
+++ b/src/main/java/skhu/hanziboong/member/controller/MemberController.java
@@ -1,0 +1,66 @@
+package skhu.hanziboong.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import skhu.hanziboong.global.exception.model.BadRequestException;
+import skhu.hanziboong.member.dto.request.MemberRequest;
+import skhu.hanziboong.member.dto.response.MemberCreateResponse;
+import skhu.hanziboong.member.dto.response.MemberResponse;
+import skhu.hanziboong.member.service.MemberService;
+
+@Tag(name = "사용자")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Operation(summary = "사용자 생성")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "요청 Body에 올바르지 않은 값이 전달되었을 때",
+                    content = @Content(schema = @Schema(implementation = BadRequestException.class))
+            ),
+    })
+    @PostMapping
+    public ResponseEntity<MemberCreateResponse> createMember(MemberRequest request) {
+        MemberCreateResponse response = memberService.createMember(request);
+
+        return ResponseEntity.created(URI.create("/api/members/" + response.id())).build();
+    }
+
+    @Operation(summary = "ID 기준 사용자 단건 상세 조회")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "존재하지 않는 규칙 ID로 요청했을 때",
+                    content = @Content(schema = @Schema(implementation = BadRequestException.class))
+            ),
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<MemberResponse> findMember(@PathVariable Long id) {
+        return ResponseEntity.ok(memberService.findMemberById(id));
+    }
+}

--- a/src/main/java/skhu/hanziboong/member/domain/Member.java
+++ b/src/main/java/skhu/hanziboong/member/domain/Member.java
@@ -38,4 +38,8 @@ public class Member extends BaseEntity {
         this.nickname = nickname;
         this.house = house;
     }
+
+    public Long getHouseId() {
+        return house.getId();
+    }
 }

--- a/src/main/java/skhu/hanziboong/member/dto/request/MemberRequest.java
+++ b/src/main/java/skhu/hanziboong/member/dto/request/MemberRequest.java
@@ -1,0 +1,14 @@
+package skhu.hanziboong.member.dto.request;
+
+import skhu.hanziboong.house.domain.House;
+import skhu.hanziboong.member.domain.Member;
+
+public record MemberRequest(
+        String username,
+        String nickname,
+        Long houseId
+) {
+    public Member toMember(House house) {
+        return new Member(username, nickname, house);
+    }
+}

--- a/src/main/java/skhu/hanziboong/member/dto/response/MemberCreateResponse.java
+++ b/src/main/java/skhu/hanziboong/member/dto/response/MemberCreateResponse.java
@@ -1,0 +1,11 @@
+package skhu.hanziboong.member.dto.response;
+
+import skhu.hanziboong.member.domain.Member;
+
+public record MemberCreateResponse(
+        Long id
+) {
+    public static MemberCreateResponse from(Member member) {
+        return new MemberCreateResponse(member.getId());
+    }
+}

--- a/src/main/java/skhu/hanziboong/member/dto/response/MemberResponse.java
+++ b/src/main/java/skhu/hanziboong/member/dto/response/MemberResponse.java
@@ -1,0 +1,19 @@
+package skhu.hanziboong.member.dto.response;
+
+import lombok.Builder;
+import skhu.hanziboong.member.domain.Member;
+
+@Builder
+public record MemberResponse(
+        Long id,
+        String nickname,
+        Long houseId
+) {
+    public static MemberResponse from(Member member) {
+        return MemberResponse.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .houseId(member.getHouseId())
+                .build();
+    }
+}

--- a/src/main/java/skhu/hanziboong/member/service/MemberService.java
+++ b/src/main/java/skhu/hanziboong/member/service/MemberService.java
@@ -1,0 +1,37 @@
+package skhu.hanziboong.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import skhu.hanziboong.house.domain.House;
+import skhu.hanziboong.house.repository.HouseRepository;
+import skhu.hanziboong.member.domain.Member;
+import skhu.hanziboong.member.dto.request.MemberRequest;
+import skhu.hanziboong.member.dto.response.MemberCreateResponse;
+import skhu.hanziboong.member.dto.response.MemberResponse;
+import skhu.hanziboong.member.repository.MemberRepository;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final HouseRepository houseRepository;
+
+    @Transactional
+    public MemberCreateResponse createMember(MemberRequest request) {
+        House house = houseRepository.findById(request.houseId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 집입니다."));
+        Member member = memberRepository.save(request.toMember(house));
+
+        return MemberCreateResponse.from(member);
+    }
+
+    @Transactional(readOnly = true)
+    public MemberResponse findMemberById(Long id) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        return MemberResponse.from(member);
+    }
+}

--- a/src/main/java/skhu/hanziboong/rule/controller/RuleController.java
+++ b/src/main/java/skhu/hanziboong/rule/controller/RuleController.java
@@ -1,7 +1,18 @@
 package skhu.hanziboong.rule.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,11 +22,14 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import skhu.hanziboong.global.exception.model.BadRequestException;
+import skhu.hanziboong.global.exception.model.UnAuthorizedException;
 import skhu.hanziboong.rule.dto.request.RuleRequest;
 import skhu.hanziboong.rule.dto.response.RuleCreateResponse;
 import skhu.hanziboong.rule.dto.response.RuleResponse;
 import skhu.hanziboong.rule.service.RuleService;
 
+@Tag(name = "규칙")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/rules")
@@ -23,6 +37,18 @@ public class RuleController {
 
     private final RuleService ruleService;
 
+    @Operation(summary = "규칙 생성")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "요청 Body에 올바르지 않은 값이 전달되었을 때",
+                    content = @Content(schema = @Schema(implementation = BadRequestException.class))
+            ),
+    })
     @PostMapping
     public ResponseEntity<Void> createRule(
             @RequestBody RuleRequest request
@@ -32,11 +58,64 @@ public class RuleController {
         return ResponseEntity.created(URI.create("/api/rules/" + response.id())).build();
     }
 
+    @Operation(summary = "ID 기준 규칙 단건 상세 조회")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "존재하지 않는 규칙 ID로 요청했을 때",
+                    content = @Content(schema = @Schema(implementation = BadRequestException.class))
+            ),
+    })
     @GetMapping("/{id}")
     public ResponseEntity<RuleResponse> findRule(@PathVariable Long id) {
         return ResponseEntity.ok(ruleService.findRuleById(id));
     }
 
+    @Operation(summary = "집 ID 기준 전체 규칙 목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "존재하지 않는 집 ID로 요청했을 때",
+                    content = @Content(schema = @Schema(implementation = BadRequestException.class))
+            ),
+    })
+    @GetMapping("/house/{id}")
+    public ResponseEntity<Page<RuleResponse>> findRulesByHouse(
+            @PathVariable
+            Long id,
+            @Parameter(hidden = true)
+            @PageableDefault(size = 5, sort = "id", direction = Direction.ASC)
+            Pageable pageable
+    ) {
+        return ResponseEntity.ok(ruleService.findRulesByHouseId(id, pageable));
+    }
+
+    // TODO: 로그인 구현 후, 인증/인가 예외처리 필요
+    @Operation(summary = "규칙 수정")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "요청 Body에 올바르지 않은 값이 전달되었을 때",
+                    content = @Content(schema = @Schema(implementation = BadRequestException.class))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "작성자가 아닌 사용자가 요청했을 때",
+                    content = @Content(schema = @Schema(implementation = UnAuthorizedException.class))
+            )
+    })
     @PutMapping("/{id}")
     public ResponseEntity<Void> updateRule(
             @PathVariable Long id,
@@ -47,6 +126,24 @@ public class RuleController {
         return ResponseEntity.ok().build();
     }
 
+    // TODO: 로그인 구현 후, 인증/인가 예외처리 필요
+    @Operation(summary = "규칙 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "존재하지 않는 여행기 ID로 요청했을 때",
+                    content = @Content(schema = @Schema(implementation = BadRequestException.class))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "작성자가 아닌 사용자가 요청했을 때",
+                    content = @Content(schema = @Schema(implementation = UnAuthorizedException.class))
+            )
+    })
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteRule(@PathVariable Long id) {
         ruleService.deleteRuleById(id);

--- a/src/main/java/skhu/hanziboong/rule/controller/RuleController.java
+++ b/src/main/java/skhu/hanziboong/rule/controller/RuleController.java
@@ -50,9 +50,7 @@ public class RuleController {
             ),
     })
     @PostMapping
-    public ResponseEntity<Void> createRule(
-            @RequestBody RuleRequest request
-    ) {
+    public ResponseEntity<Void> createRule(@RequestBody RuleRequest request) {
         RuleCreateResponse response = ruleService.createRule(request);
 
         return ResponseEntity.created(URI.create("/api/rules/" + response.id())).build();

--- a/src/main/java/skhu/hanziboong/rule/dto/request/RuleRequest.java
+++ b/src/main/java/skhu/hanziboong/rule/dto/request/RuleRequest.java
@@ -1,18 +1,14 @@
 package skhu.hanziboong.rule.dto.request;
 
-import skhu.hanziboong.house.domain.House;
-import skhu.hanziboong.house.domain.HouseType;
 import skhu.hanziboong.member.domain.Member;
 import skhu.hanziboong.rule.domain.Rule;
 
 public record RuleRequest(
         String title,
-        String description
+        String description,
+        Long memberId
 ) {
-    public Rule toRule() {
-        // TODO: house와 member는 임시 객체이므로 기능 구현 후 대체해야 함.
-        House house = new House(HouseType.MONTHLY_RENT);
-        Member member = new Member("username", "nickname", house);
+    public Rule toRule(Member member) {
         return new Rule(title, description, member);
     }
 }

--- a/src/main/java/skhu/hanziboong/rule/repository/RuleRepository.java
+++ b/src/main/java/skhu/hanziboong/rule/repository/RuleRepository.java
@@ -1,9 +1,14 @@
 package skhu.hanziboong.rule.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import skhu.hanziboong.house.domain.House;
 import skhu.hanziboong.rule.domain.Rule;
 
 @Repository
 public interface RuleRepository extends JpaRepository<Rule, Long> {
+
+    Page<Rule> findAllByHouse(House house, Pageable pageable);
 }

--- a/src/main/java/skhu/hanziboong/rule/service/RuleService.java
+++ b/src/main/java/skhu/hanziboong/rule/service/RuleService.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import skhu.hanziboong.house.domain.House;
 import skhu.hanziboong.house.repository.HouseRepository;
+import skhu.hanziboong.member.domain.Member;
+import skhu.hanziboong.member.repository.MemberRepository;
 import skhu.hanziboong.rule.domain.Rule;
 import skhu.hanziboong.rule.dto.request.RuleRequest;
 import skhu.hanziboong.rule.dto.response.RuleCreateResponse;
@@ -18,11 +20,14 @@ import skhu.hanziboong.rule.repository.RuleRepository;
 public class RuleService {
 
     private final RuleRepository ruleRepository;
+    private final MemberRepository memberRepository;
     private final HouseRepository houseRepository;
 
     @Transactional
     public RuleCreateResponse createRule(RuleRequest request) {
-        Rule rule = ruleRepository.save(request.toRule());
+        Member member = memberRepository.findById(request.memberId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Rule rule = ruleRepository.save(request.toRule(member));
 
         return RuleCreateResponse.from(rule);
     }

--- a/src/main/java/skhu/hanziboong/rule/service/RuleService.java
+++ b/src/main/java/skhu/hanziboong/rule/service/RuleService.java
@@ -1,8 +1,12 @@
 package skhu.hanziboong.rule.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import skhu.hanziboong.house.domain.House;
+import skhu.hanziboong.house.repository.HouseRepository;
 import skhu.hanziboong.rule.domain.Rule;
 import skhu.hanziboong.rule.dto.request.RuleRequest;
 import skhu.hanziboong.rule.dto.response.RuleCreateResponse;
@@ -14,6 +18,7 @@ import skhu.hanziboong.rule.repository.RuleRepository;
 public class RuleService {
 
     private final RuleRepository ruleRepository;
+    private final HouseRepository houseRepository;
 
     @Transactional
     public RuleCreateResponse createRule(RuleRequest request) {
@@ -28,6 +33,15 @@ public class RuleService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 규칙입니다."));
 
         return RuleResponse.from(rule);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<RuleResponse> findRulesByHouseId(Long id, Pageable pageable) {
+        House house = houseRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 집입니다."));
+
+        Page<Rule> rules = ruleRepository.findAllByHouse(house, pageable);
+        return rules.map(RuleResponse::from);
     }
 
     @Transactional

--- a/src/main/java/skhu/hanziboong/schedule/controller/ScheduleController.java
+++ b/src/main/java/skhu/hanziboong/schedule/controller/ScheduleController.java
@@ -48,7 +48,7 @@ public class ScheduleController {
     public ResponseEntity<ScheduleCreateResponse> createSchedule(@RequestBody ScheduleRequest request) {
         ScheduleCreateResponse response = scheduleService.createSchedule(request);
 
-        return ResponseEntity.created(URI.create("/api/schedule/" + response.id())).build();
+        return ResponseEntity.created(URI.create("/api/schedules/" + response.id())).build();
     }
 
     @Operation(summary = "집 ID, 연도, 월 기준 일정 목록 조회")

--- a/src/main/java/skhu/hanziboong/schedule/controller/ScheduleController.java
+++ b/src/main/java/skhu/hanziboong/schedule/controller/ScheduleController.java
@@ -1,27 +1,74 @@
 package skhu.hanziboong.schedule.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import skhu.hanziboong.global.exception.model.BadRequestException;
 import skhu.hanziboong.schedule.dto.request.ScheduleRequest;
+import skhu.hanziboong.schedule.dto.response.ScheduleCreateResponse;
+import skhu.hanziboong.schedule.dto.response.ScheduleResponse;
 import skhu.hanziboong.schedule.service.ScheduleService;
 
+@Tag(name = "일정")
 @RestController
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-@RequestMapping("/api/schedule")
+@RequestMapping("/api/schedules")
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
 
+    @Operation(summary = "일정 생성")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "요청 Body에 올바르지 않은 값이 전달되었을 때",
+                    content = @Content(schema = @Schema(implementation = BadRequestException.class))
+            ),
+    })
     @PostMapping
-    public ResponseEntity<Void> createSchedule(@RequestBody ScheduleRequest request) {
-        scheduleService.createSchedule(request);
-        
-        return ResponseEntity.created(URI.create("/api/schedule/" + request.houseId())).build();
+    public ResponseEntity<ScheduleCreateResponse> createSchedule(@RequestBody ScheduleRequest request) {
+        ScheduleCreateResponse response = scheduleService.createSchedule(request);
+
+        return ResponseEntity.created(URI.create("/api/schedule/" + response.id())).build();
+    }
+
+    @Operation(summary = "집 ID, 연도, 월 기준 일정 목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "존재하지 않는 집 ID로 요청했을 때",
+                    content = @Content(schema = @Schema(implementation = BadRequestException.class))
+            ),
+    })
+    @GetMapping("/house/{houseId}")
+    public ResponseEntity<List<ScheduleResponse>> findSchedulesByHouseAndYearAndMonth(
+            @PathVariable Long houseId,
+            @RequestParam("year") Integer year,
+            @RequestParam("month") Integer month
+    ) {
+        return ResponseEntity.ok(scheduleService.getSchedulesByHouseAndYearAndMonth(houseId, year, month));
     }
 }

--- a/src/main/java/skhu/hanziboong/schedule/domain/Schedule.java
+++ b/src/main/java/skhu/hanziboong/schedule/domain/Schedule.java
@@ -1,6 +1,5 @@
 package skhu.hanziboong.schedule.domain;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,11 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,7 +20,7 @@ import skhu.hanziboong.house.domain.House;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Schedule extends BaseEntity {
-
+    
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/skhu/hanziboong/schedule/domain/ScheduleParticipant.java
+++ b/src/main/java/skhu/hanziboong/schedule/domain/ScheduleParticipant.java
@@ -43,6 +43,10 @@ public class ScheduleParticipant extends BaseEntity {
         this.member = member;
     }
 
+    public String getMemberName() {
+        return member.getNickname();
+    }
+
     @EqualsAndHashCode.Include
     private Long scheduleId() {
         if (schedule == null) {

--- a/src/main/java/skhu/hanziboong/schedule/dto/response/ScheduleCreateResponse.java
+++ b/src/main/java/skhu/hanziboong/schedule/dto/response/ScheduleCreateResponse.java
@@ -1,0 +1,11 @@
+package skhu.hanziboong.schedule.dto.response;
+
+import skhu.hanziboong.schedule.domain.Schedule;
+
+public record ScheduleCreateResponse(
+        Long id
+) {
+    public static ScheduleCreateResponse from(Schedule schedule) {
+        return new ScheduleCreateResponse(schedule.getId());
+    }
+}

--- a/src/main/java/skhu/hanziboong/schedule/dto/response/ScheduleResponse.java
+++ b/src/main/java/skhu/hanziboong/schedule/dto/response/ScheduleResponse.java
@@ -1,0 +1,34 @@
+package skhu.hanziboong.schedule.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import skhu.hanziboong.schedule.domain.Schedule;
+import skhu.hanziboong.schedule.domain.ScheduleParticipant;
+
+@Builder
+public record ScheduleResponse(
+        Long id,
+        String title,
+        String description,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        List<String> participants
+) {
+    public static ScheduleResponse from(Schedule schedule, List<ScheduleParticipant> participants) {
+        return ScheduleResponse.builder()
+                .id(schedule.getId())
+                .title(schedule.getTitle())
+                .description(schedule.getDescription())
+                .startAt(schedule.getStartAt())
+                .endAt(schedule.getEndAt())
+                .participants(getNames(participants))
+                .build();
+    }
+
+    private static List<String> getNames(List<ScheduleParticipant> participants) {
+        return participants.stream()
+                .map(ScheduleParticipant::getMemberName)
+                .toList();
+    }
+}

--- a/src/main/java/skhu/hanziboong/schedule/repository/ScheduleParticipantRepository.java
+++ b/src/main/java/skhu/hanziboong/schedule/repository/ScheduleParticipantRepository.java
@@ -1,7 +1,13 @@
 package skhu.hanziboong.schedule.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import skhu.hanziboong.schedule.domain.Schedule;
 import skhu.hanziboong.schedule.domain.ScheduleParticipant;
 
+@Repository
 public interface ScheduleParticipantRepository extends JpaRepository<ScheduleParticipant, Long> {
+    
+    List<ScheduleParticipant> findAllBySchedule(Schedule schedule);
 }

--- a/src/main/java/skhu/hanziboong/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/skhu/hanziboong/schedule/repository/ScheduleRepository.java
@@ -1,7 +1,14 @@
 package skhu.hanziboong.schedule.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import skhu.hanziboong.house.domain.House;
 import skhu.hanziboong.schedule.domain.Schedule;
 
+@Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+    List<Schedule> findByHouseAndStartAtBetween(House house, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -25,3 +25,16 @@ logging:
   level:
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql: TRACE
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs  # 기본 스펙 JSON 경로
+  swagger-ui:
+    path: /swagger-ui.html  # Swagger UI 접속 경로
+    operationsSorter: alpha  # API 목록 알파벳 순 정렬
+    tagsSorter: alpha        # 태그 알파벳 순 정렬
+    display-request-duration: true  # 요청/응답 시간 표시
+    syntax-highlight:
+      theme: nord            # 코드 하이라이트 테마
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,13 +28,13 @@ logging:
 
 springdoc:
   api-docs:
-    path: /v3/api-docs  # 기본 스펙 JSON 경로
+    path: /v3/api-docs
   swagger-ui:
-    path: /swagger-ui.html  # Swagger UI 접속 경로
-    operationsSorter: alpha  # API 목록 알파벳 순 정렬
-    tagsSorter: alpha        # 태그 알파벳 순 정렬
-    display-request-duration: true  # 요청/응답 시간 표시
+    path: /swagger-ui.html
+    operationsSorter: alpha
+    tagsSorter: alpha
+    display-request-duration: true
     syntax-highlight:
-      theme: nord            # 코드 하이라이트 테마
+      theme: nord
   default-consumes-media-type: application/json
   default-produces-media-type: application/json

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,13 +17,13 @@ spring:
 
 springdoc:
   api-docs:
-    path: /v3/api-docs  # 기본 스펙 JSON 경로
+    path: /v3/api-docs
   swagger-ui:
-    path: /swagger-ui.html  # Swagger UI 접속 경로
-    operationsSorter: alpha  # API 목록 알파벳 순 정렬
-    tagsSorter: alpha        # 태그 알파벳 순 정렬
-    display-request-duration: true  # 요청/응답 시간 표시
+    path: /swagger-ui.html
+    operationsSorter: alpha
+    tagsSorter: alpha
+    display-request-duration: true
     syntax-highlight:
-      theme: nord            # 코드 하이라이트 테마
+      theme: nord
   default-consumes-media-type: application/json
   default-produces-media-type: application/json

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,3 +14,16 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs  # 기본 스펙 JSON 경로
+  swagger-ui:
+    path: /swagger-ui.html  # Swagger UI 접속 경로
+    operationsSorter: alpha  # API 목록 알파벳 순 정렬
+    tagsSorter: alpha        # 태그 알파벳 순 정렬
+    display-request-duration: true  # 요청/응답 시간 표시
+    syntax-highlight:
+      theme: nord            # 코드 하이라이트 테마
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json


### PR DESCRIPTION
## 작업 내용

- OpenAPI 3.1.0을 도입했습니다.
- 집 도메인의 생성 API를 구현하고 문서화했습니다.
- 사용자 도메인의 생성, 조회 API를 구현하고 문서화했습니다.
- 규칙 도메인의 API를 문서화했습니다.
- 일정 도메인의 API를 문서화했습니다.

## 참고 사항

1. 모든 API가 정상 동작하는지 확인하기 위해 단위 테스트 작성이 필요합니다.
2. 프론트엔드 팀원과 논의해 추가로 필요한 API가 있는지 회의해야 합니다.