### PR TITLE
[Fix] 공동 지출 내역 삭제 api 로직 수정

### DIFF
--- a/src/main/java/skhu/hanziboong/expense/repository/ExpenseParticipantRepository.java
+++ b/src/main/java/skhu/hanziboong/expense/repository/ExpenseParticipantRepository.java
@@ -21,4 +21,6 @@ public interface ExpenseParticipantRepository extends JpaRepository<ExpenseParti
     where ep.expense.id in :expenseIds
     """)
     List<ExpenseParticipant> findByExpenseIds(@Param("expenseIds") List<Long> expenseIds);
+
+    void deleteByExpense_Id(Long id);
 }

--- a/src/main/java/skhu/hanziboong/expense/service/ExpenseService.java
+++ b/src/main/java/skhu/hanziboong/expense/service/ExpenseService.java
@@ -127,6 +127,7 @@ public class ExpenseService {
 
     @Transactional
     public void deleteExpenseByExpenseId(Long id) {
+        expenseParticipantRepository.deleteByExpense_Id(id);
         expenseRepository.deleteById(id);
     }
 }


### PR DESCRIPTION
### 작업 내용
- 공동 지출 내역 삭제 api가 fk 제약 조건을 위배하고 있는 버그를 수정했습니다

관련 이슈
#26 